### PR TITLE
Fix for issue #32

### DIFF
--- a/AuthenticodeLint/AuthenticodeLint.csproj
+++ b/AuthenticodeLint/AuthenticodeLint.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>WinExe</OutputType>
+    <OutputType>Exe</OutputType>
     <AssemblyName>authlint</AssemblyName>
     <PackageId>AuthenticodeLint</PackageId>
     <TargetFramework>net6.0</TargetFramework>


### PR DESCRIPTION
I think WinExe OutputType means a GUI application, whereas Exe just means a console application.